### PR TITLE
replaced system("pause"); with cin.get();

### DIFF
--- a/MultipleClientsBarebonesServer/MultipleClientsBarebonesServer/main.cpp
+++ b/MultipleClientsBarebonesServer/MultipleClientsBarebonesServer/main.cpp
@@ -162,5 +162,6 @@ void main()
 	// Cleanup winsock
 	WSACleanup();
 
-	system("pause");
+	cout << "Press Enter to Exit.";
+	cin.get();
 }


### PR DESCRIPTION
cin.get is a more customizable and better standardized method of pausing before exiting.